### PR TITLE
Fixing run script to run when instance directory is mounted.

### DIFF
--- a/opendj-nightly/Dockerfile
+++ b/opendj-nightly/Dockerfile
@@ -2,18 +2,11 @@ FROM java:8
 
 MAINTAINER warren.strange@gmail.com
 
-WORKDIR /opt
-
-
-
-RUN curl https://forgerock.org/djs/opendjrel.js?948497823 | grep -o "http://.*\.zip" | tail -1 | xargs curl -o opendj.zip
-
-RUN unzip opendj.zip && ./opendj/setup --cli -p 389 --ldapsPort 636 --enableStartTLS --generateSelfSignedCertificate \
-    --sampleData 100 --baseDN "dc=example,dc=com" -h localhost --rootUserPassword password --acceptLicense --no-prompt \
-    && rm opendj.zip && /opt/opendj/bin/stop-ds
-
+WORKDIR /opt/opendj
 
 ADD run.sh /opt/opendj/run.sh
+
+VOLUME ["/installers", "/opt/opendj/instance/logs", "/opt/opendj/instance/db"]
 
 EXPOSE 389 636 4444
 
@@ -22,4 +15,3 @@ EXPOSE 389 636 4444
 # These dirs need to be copied to instance.loc:  config	db	locks	logs
 
 CMD  ["/opt/opendj/run.sh"]
-

--- a/opendj-nightly/run.sh
+++ b/opendj-nightly/run.sh
@@ -8,13 +8,56 @@
 
 cd /opt/opendj
 
-# Instance dir does not exist?
-if [ ! -d instance ] ; then
-  mkdir instance
-  mv config/ instance
-  mv db/ instance
-  mkdir instance/logs
-  mkdir instance/locks
+if [ ! -d bin ] ; then
+
+  if [ ! -e /installers/opendj.zip ] ; then
+    curl https://forgerock.org/djs/opendjrel.js?948497823 | grep -o "http://.*\.zip" | tail -1 | xargs curl -o /opt/opendj.zip;
+    if [ -w /installers/ ] ; then
+      cp /opt/opendj.zip /installers/
+    fi
+  else
+    cp /installers/opendj.zip /opt/opendj.zip
+  fi
+
+  if [ ! -e response_file.props ] ; then
+    cat > response_file.props <<EOF
+#
+# Sample properties file to set up OpenDJ directory server
+#
+hostname                        =localhost
+ldapPort                        =389
+generateSelfSignedCertificate   =true
+enableStartTLS                  =true
+ldapsPort                       =636
+jmxPort                         =689
+adminConnectorPort              =4444
+rootUserDN                      =cn=Directory Manager
+rootUserPassword                =password
+baseDN                          =dc=example,dc=com
+sampleData                      =100
+doNotStart                      =true
+EOF
+
+  fi
+
+  unzip /opt/opendj.zip -d /opt && /opt/opendj/setup --cli --propertiesFilePath response_file.props --acceptLicense --no-prompt \
+      && /opt/opendj/bin/stop-ds && rm /opt/opendj.zip
+
+  sleep 5
+fi
+
+cd /opt/opendj
+
+# have config dir not been moved?
+if [ -d config ] ; then
+  mkdir -p instance/logs
+  mkdir -p instance/locks
+  mkdir -p instance/db
+  mkdir -p instance/config
+
+  mv config/* instance/config/
+  mv db/* instance/db/
+
   echo "./instance" > instance.loc
 fi
 


### PR DESCRIPTION
Fixing Docker and run script to run when /opt/opendj/instance/{logs,logs} are mounted as volume.

moving the download of opendj zip file from Dockerfile to the first time run, so we can reuse the instance to run with provisioned opendj zip